### PR TITLE
chore: streamline CLI and fix ESM compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Modern, LLM-ready accessibility auditing utilities for WCAG 2.2 Level AA complia
 Build and run the Crochet command-line interface:
 
 ```bash
-pnpm cli:build         # bundle @crochet/cli via tsup
-pnpm --filter @crochet/cli exec crochet schema-list
-pnpm --filter @crochet/cli exec crochet schema-validate examples/reports/accessibility-gaps.sample.json
+pnpm install           # builds the CLI during prepare
+pnpm run crochet schema-list
+pnpm run crochet schema-validate examples/reports/accessibility-gaps.sample.json
 ```
 
-The CLI currently supports protocol inspection (`crochet protocol-info`) and JSON schema validation (`crochet schema-validate`).
+The CLI currently supports protocol inspection (`crochet protocol-info`) and JSON schema validation (`crochet schema-validate`). Use `pnpm cli:build` if you need to regenerate the bundle manually.
 
 ## Contributing
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,10 +39,21 @@ Transform the accessibility audit workflow into a reusable public utility that s
 
 ## Phase 3 – CLI & Automation (In Progress)
 - ✅ Scaffold CLI package (`packages/cli`) with protocol inspection and schema validation commands.
-- Implement framework adapters (React/MUI baseline) via dependency inversion.
 - ✅ Integrate Vitest coverage for CLI utilities (schema + protocol modules).
+- ✅ Fix Node.js ESM JSON import compatibility (runtime schema loading).
+- ✅ CLI commands functional: `protocol-info`, `schema-list`, `schema-validate`.
+- ✅ Prepare hook builds CLI automatically on `pnpm install`.
+- Implement framework adapters (React/MUI baseline) via dependency inversion.
 - Wire Playwright + `@axe-core/playwright` smoke suite gated by CI flag.
 - Publish reusable GitHub Action to run CLI in consumer pipelines.
+
+### Phase 3 Success Criteria (Partial)
+- ✅ CLI commands execute without errors (`schema-list`, `protocol-info`, `schema-validate`).
+- ✅ All quality gates pass: lint, test (3/3), typecheck, schema validation.
+- ✅ CLI builds via prepare hook (ESM-only bundle with tsup).
+- ⏳ Framework adapters pending.
+- ⏳ Playwright integration pending.
+- ⏳ GitHub Action pending.
 
 ## Phase 4 – Documentation & Education
 - Stand up docs site (Docusaurus) with quick start, architecture overview, troubleshooting, and learning resources.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ export default tseslint.config(
   {
     ignores: [
       'dist',
+      'packages/**/dist/**/*',
       'coverage',
       'reports',
       'node_modules',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "schema:types": "node scripts/generate-schema-types.mjs",
     "schema:validate": "node scripts/validate-schemas.mjs",
     "cli:build": "pnpm --filter @crochet/cli build",
-    "cli:dev": "pnpm --filter @crochet/cli dev"
+    "cli:dev": "pnpm --filter @crochet/cli dev",
+    "crochet": "node packages/cli/dist/index.js"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,8 +10,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
-    "dev": "tsup src/index.ts --format esm --watch --dts"
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --watch --dts",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "commander": "^12.1.0",

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import Ajv, { ErrorObject } from 'ajv';
+import Ajv from 'ajv';
+import type { ErrorObject } from 'ajv';
 import addFormats from 'ajv-formats';
 import accessibilityGapsSchema from '@crochet/schemas/accessibility-gaps.schema.json' assert { type: 'json' };
 import contrastValidationSchema from '@crochet/schemas/contrast-validation.schema.json' assert { type: 'json' };

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1,17 +1,31 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Ajv from 'ajv';
 import type { ErrorObject } from 'ajv';
 import addFormats from 'ajv-formats';
-import accessibilityGapsSchema from '@crochet/schemas/accessibility-gaps.schema.json' assert { type: 'json' };
-import contrastValidationSchema from '@crochet/schemas/contrast-validation.schema.json' assert { type: 'json' };
 
 type SchemaKey = 'accessibility-gaps' | 'contrast-validation';
 
-const schemaMap: Record<SchemaKey, Record<string, unknown>> = {
-  'accessibility-gaps': accessibilityGapsSchema as Record<string, unknown>,
-  'contrast-validation': contrastValidationSchema as Record<string, unknown>
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const schemaMap: Record<SchemaKey, string> = {
+  'accessibility-gaps': 'accessibility-gaps.schema.json',
+  'contrast-validation': 'contrast-validation.schema.json'
 };
+
+async function loadSchema(schemaKey: SchemaKey): Promise<Record<string, unknown>> {
+  const schemaFileName = schemaMap[schemaKey];
+  if (!schemaFileName) {
+    throw new Error(`Unknown schema: ${schemaKey}`);
+  }
+
+  // Navigate from dist/ to packages/schemas/
+  const schemaPath = path.resolve(__dirname, '../../schemas', schemaFileName);
+  const schemaContent = await fs.readFile(schemaPath, 'utf8');
+  return JSON.parse(schemaContent) as Record<string, unknown>;
+}
 
 export interface ValidationResult {
   valid: boolean;
@@ -23,10 +37,7 @@ export function listSchemas(): SchemaKey[] {
 }
 
 export async function validateReport(schemaKey: SchemaKey, reportPath: string): Promise<ValidationResult> {
-  const schema = schemaMap[schemaKey];
-  if (!schema) {
-    throw new Error(`Unknown schema: ${schemaKey}`);
-  }
+  const schema = await loadSchema(schemaKey);
 
   const resolvedReportPath = path.resolve(process.cwd(), reportPath);
   const fileContents = await fs.readFile(resolvedReportPath, 'utf8');

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

This PR completes the core CLI functionality for Phase 3 by streamlining CLI execution and fixing Node.js v22 ESM compatibility issues.

### Changes

- **ESM Compatibility Fix**: Replaced static JSON imports with runtime schema loading to resolve Node.js v22 import attribute requirements that were being stripped by tsup bundler
- **CLI Streamlining**: 
  - Updated README with correct CLI usage instructions
  - Added prepare hook to auto-build CLI on `pnpm install`
  - Configured ESLint to ignore dist/ output
  - Enhanced TypeScript configuration for better ESM support

### Commits

- fix: replace static JSON imports with runtime schema loading (64ccb4b)
- chore: streamline cli usage (18351b9)

## Testing

All CLI commands verified working:
```bash
pnpm run crochet schema-list
pnpm run crochet protocol-info
pnpm run crochet schema-validate examples/reports/accessibility-gaps.sample.json
```

All quality gates passing:
- ✅ Lint
- ✅ Tests (3/3 passing)
- ✅ Typecheck
- ✅ Schema validation

## Phase 3 Progress

Updated ROADMAP.md to reflect:
- ✅ CLI commands functional
- ✅ Vitest coverage integrated
- ✅ ESM compatibility resolved
- ✅ Prepare hook auto-build

Remaining Phase 3 items (future PRs):
- Framework adapters (React/MUI)
- Playwright integration
- GitHub Action

🤖 Generated with [Claude Code](https://claude.com/claude-code)